### PR TITLE
Add shopping lists for cooking and crafting pages

### DIFF
--- a/apps/stardew.app/src/components/cards/bundle-item-card.tsx
+++ b/apps/stardew.app/src/components/cards/bundle-item-card.tsx
@@ -5,8 +5,10 @@ import { Dispatch, SetStateAction } from "react";
 import { usePlayers } from "@/contexts/players-context";
 
 import { categoryIcons, goldIcons } from "@/lib/constants";
-import { BundleItem, BundleItemWithLocation } from "@/types/bundles";
+import { BundleItemWithLocation } from "@/types/bundles";
 import { BooleanCard } from "./boolean-card";
+
+import { categoryItems } from "@/lib/utils";
 
 interface BundleItemCardProps {
 	item: BundleItemWithLocation;
@@ -27,23 +29,6 @@ interface BundleItemCardProps {
 	 * @memberof BundleItemCardProps
 	 */
 	setPromptOpen?: Dispatch<SetStateAction<boolean>>;
-}
-
-const categoryItems: Record<string, string> = {
-	"-4": "Any Fish",
-	"-5": "Any Egg",
-	"-6": "Any Milk",
-	"-777": "Wild Seeds (Any)",
-};
-
-export function bundleItemName<T extends BundleItem>(item: T): string {
-	if (item.itemID == "-1") {
-		return "Gold";
-	} else if (item.itemID in categoryItems) {
-		return categoryItems[item.itemID];
-	}
-
-	return objects[item.itemID as keyof typeof objects]?.name;
 }
 
 export const BundleItemCard = ({

--- a/apps/stardew.app/src/components/required-ingredients-list.tsx
+++ b/apps/stardew.app/src/components/required-ingredients-list.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { InfoCard } from "./cards/info-card";
+import {
+	Accordion,
+	AccordionContent,
+	AccordionItem,
+	AccordionTrigger,
+} from "./ui/accordion";
+
+interface RequiredIngredientsListProps {
+	title: string;
+	requiredIngredients: {
+		itemID: string;
+		name: string;
+		quantity: number;
+		sourceURL: string;
+	}[];
+}
+
+export const RequiredIngredientsList: React.FC<
+	RequiredIngredientsListProps
+> = ({ title, requiredIngredients }) => {
+	return (
+		<Accordion type="single" collapsible defaultValue="item-1" asChild>
+			<section className="space-y-3">
+				<AccordionItem value="item-1">
+					<AccordionTrigger className="ml-1 pt-0 text-xl font-semibold text-gray-900 dark:text-white">
+						{title}
+					</AccordionTrigger>
+					<AccordionContent asChild>
+						<div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+							{requiredIngredients.map((ingredient) => (
+								<InfoCard
+									key={ingredient.itemID}
+									title={ingredient.name}
+									description={`x${ingredient.quantity}`}
+									sourceURL={ingredient.sourceURL}
+								/>
+							))}
+						</div>
+					</AccordionContent>
+				</AccordionItem>
+			</section>
+		</Accordion>
+	);
+};
+
+RequiredIngredientsList.displayName = "RequiredIngredientsList";

--- a/apps/stardew.app/src/contexts/feature-gate-context.tsx
+++ b/apps/stardew.app/src/contexts/feature-gate-context.tsx
@@ -1,0 +1,60 @@
+import { useRouter } from "next/router";
+import { createContext, ReactNode, useCallback, useContext } from "react";
+
+interface FeatureGateContextType {
+	isFeatureEnabled: (feature: keyof typeof FEATURE_GATES) => boolean;
+}
+
+const FeatureGateContext = createContext<FeatureGateContextType | undefined>(
+	undefined,
+);
+
+const FEATURE_GATES = {
+	"cooking-ingredients": {
+		enabled: false,
+		queryParam: "cooking-ingredients",
+		description: "Show the ingredients needed to cook all shown recipes",
+	},
+	"crafting-ingredients": {
+		enabled: false,
+		queryParam: "crafting-ingredients",
+		description: "Show the ingredients needed to craft all shown recipes",
+	},
+};
+
+export function FeatureGateProvider({ children }: { children: ReactNode }) {
+	const { query } = useRouter();
+
+	const isFeatureEnabled = useCallback(
+		(feature: keyof typeof FEATURE_GATES) => {
+			if (query[FEATURE_GATES[feature].queryParam] === "1") {
+				return true;
+			}
+
+			if (query[FEATURE_GATES[feature].queryParam] === "0") {
+				return false;
+			}
+
+			return FEATURE_GATES[feature].enabled;
+		},
+		[query],
+	);
+
+	return (
+		<FeatureGateContext.Provider
+			value={{
+				isFeatureEnabled,
+			}}
+		>
+			{children}
+		</FeatureGateContext.Provider>
+	);
+}
+
+export function useFeatureGate() {
+	const context = useContext(FeatureGateContext);
+	if (context === undefined) {
+		throw new Error("useFeatureGate must be used within a FeatureGateContext");
+	}
+	return context;
+}

--- a/apps/stardew.app/src/lib/utils.ts
+++ b/apps/stardew.app/src/lib/utils.ts
@@ -2,7 +2,11 @@ import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 import XXH from "xxhashjs";
 
+import objects from "@/data/objects.json";
+import { BundleItem } from "@/types/bundles";
+
 const semverSatisfies = require("semver/functions/satisfies");
+const semverGte = require("semver/functions/gte");
 
 export function cn(...inputs: ClassValue[]) {
 	return twMerge(clsx(inputs));
@@ -249,4 +253,21 @@ export function getRandomSeed(
 			e % 2147483647,
 		);
 	}
+}
+
+export const categoryItems: Record<string, string> = {
+	"-4": "Any Fish",
+	"-5": "Any Egg",
+	"-6": "Any Milk",
+	"-777": "Wild Seeds (Any)",
+};
+
+export function bundleItemName<T extends BundleItem>(item: T): string {
+	if (item.itemID == "-1") {
+		return "Gold";
+	} else if (item.itemID in categoryItems) {
+		return categoryItems[item.itemID];
+	}
+
+	return objects[item.itemID as keyof typeof objects]?.name;
 }

--- a/apps/stardew.app/src/pages/_app.tsx
+++ b/apps/stardew.app/src/pages/_app.tsx
@@ -7,6 +7,7 @@ import { Topbar, User } from "@/components/top-bar";
 import { Toaster } from "sonner";
 
 import { ThemeProvider } from "@/components/theme-provider";
+import { FeatureGateProvider } from "@/contexts/feature-gate-context";
 import { MultiSelectProvider } from "@/contexts/multi-select-context";
 import { PlayersProvider } from "@/contexts/players-context";
 import { PreferencesProvider } from "@/contexts/preferences-context";
@@ -29,20 +30,22 @@ export default function App({ Component, pageProps }: AppProps) {
 			<PlayersProvider>
 				<PreferencesProvider>
 					<MultiSelectProvider>
-						<div className={`${inter.className}`}>
-							<div className="sticky top-0 z-10 dark:bg-neutral-950">
-								<Topbar />
-							</div>
-							<div>
-								<Sidebar className="hidden max-h-[calc(100vh-65px)] min-h-[calc(100vh-65px)] overflow-y-auto overflow-x-clip md:fixed md:flex md:w-72 md:flex-col" />
-								<div className="md:pl-72">
-									<ErrorBoundary>
-										<Component {...pageProps} />
-									</ErrorBoundary>
-									<Toaster richColors />
+						<FeatureGateProvider>
+							<div className={`${inter.className}`}>
+								<div className="sticky top-0 z-10 dark:bg-neutral-950">
+									<Topbar />
+								</div>
+								<div>
+									<Sidebar className="hidden max-h-[calc(100vh-65px)] min-h-[calc(100vh-65px)] overflow-y-auto overflow-x-clip md:fixed md:flex md:w-72 md:flex-col" />
+									<div className="md:pl-72">
+										<ErrorBoundary>
+											<Component {...pageProps} />
+										</ErrorBoundary>
+										<Toaster richColors />
+									</div>
 								</div>
 							</div>
-						</div>
+						</FeatureGateProvider>
 					</MultiSelectProvider>
 				</PreferencesProvider>
 			</PlayersProvider>

--- a/apps/stardew.app/src/pages/bundles.tsx
+++ b/apps/stardew.app/src/pages/bundles.tsx
@@ -38,8 +38,7 @@ import { usePreferences } from "@/contexts/preferences-context";
 
 import { AchievementCard } from "@/components/cards/achievement-card";
 import {
-	BundleItemCard,
-	bundleItemName,
+	BundleItemCard
 } from "@/components/cards/bundle-item-card";
 import { UnblurDialog } from "@/components/dialogs/unblur-dialog";
 import BundleSheet from "@/components/sheets/bundle-sheet";
@@ -53,7 +52,7 @@ import {
 import { Command, CommandInput } from "@/components/ui/command";
 import { Progress } from "@/components/ui/progress";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
-import { cn } from "@/lib/utils";
+import { bundleItemName, cn } from "@/lib/utils";
 import { useMediaQuery } from "@react-hook/media-query";
 import { IconSettings } from "@tabler/icons-react";
 import clsx from "clsx";


### PR DESCRIPTION
## Description

> ⚠️ Right before opening the PR I spotted there's similar one: #157. Both cover the topic slightly differently and probably the mix would be the best solution. This PR makes no changes and hides the added functionality behind the feature gate, so the functionality may remain hidden while under construction and addresses all the community's needs.

Add the lists of all the ingredients needed for crafting/cooking all the selected recipes.

### Demo
| Crafting -- no flag (BAU) | Crafting -- with flag | Cooking -- no flag (BAU) | Cooking -- with flag |
| -- | -- | -- | -- |
| <img width="448" height="902" alt="image" src="https://github.com/user-attachments/assets/e6f6d412-dc41-4a6f-b892-87232feac462" /> | <img width="424" height="899" alt="image" src="https://github.com/user-attachments/assets/3701acd6-525e-4d8e-a0e7-ed7b7a5b71b7" /> | <img width="435" height="899" alt="image" src="https://github.com/user-attachments/assets/a9135958-05e7-4a76-a4bd-f911746b0b5a" /> | <img width="447" height="897" alt="image" src="https://github.com/user-attachments/assets/0b3c3873-89e0-414b-972c-b9f7605f49c6" /> |


### Hard changes

1. Extract the `bundleItemName` function and `categoryItems` list to utils.
2. Unify the filtering logic for cooking/crafting pages.

### Soft changes

1. Add the required cooking ingredients list -- only available if feature is enabled or by addding `cooking-ingredients` query parameter.
2. Add the required crafting ingredients list -- only available if feature is enabled or by adding `crafting-ingredients` query parameter.

## QA hints

### Scenario 1

Check the default behaviour -- no changes expected

### Scenario 2

1. Open the cooking page with `?cooking-ingredients=1` query parameter -- the ingredients list should appear and only show ingredients for the recipes appearing on the page right now.
2. Open the crafting page with `?crafting-ingredients=1` query parameter -- the ingredients list should appear and only show ingredients for the recipes appearing on the page right now.

### Scenario 3

Global rollout

1. Enable the `cooking-ingredients` or `crafting-ingredients` or both feature gates.
2. The enabled lists should appear on the relevant page without any query parameters.
3. Add `cooking-ingredients=0` or `crafting-ingredients=0` query parameter of the relevant page to disable the experimental component.

## Suggested rollout strategy

1. Merge & deploy
4. Check the functionality using the `cooking-ingredients` and `crafring-ingredients` query parameters
5. Fix bugs found by the fraction of community
6. Enable features for all
7. Fix all the reported bugs
8. Remove the feature gate dependency
