### PR TITLE
Add "Quick Actions" to cards in Shipping page

### DIFF
--- a/apps/stardew.app/src/components/cards/card-quick-actions.tsx
+++ b/apps/stardew.app/src/components/cards/card-quick-actions.tsx
@@ -1,0 +1,48 @@
+import { IconPlus } from "@tabler/icons-react";
+
+import { usePlayers } from "@/contexts/players-context";
+
+import { cn } from "@/lib/utils";
+
+import { Button, type ButtonProps } from "@/components/ui/button";
+
+interface CardQuickActionsProps {
+	addLabel: string;
+	onAdd: () => void;
+	className?: string;
+	disabled?: boolean;
+	variant?: ButtonProps["variant"];
+	size?: ButtonProps["size"];
+}
+
+export const CardQuickActions = ({
+	addLabel,
+	onAdd,
+	className,
+	disabled = false,
+	variant = "outline",
+	size = "icon",
+}: CardQuickActionsProps) => {
+	const { activePlayer } = usePlayers();
+
+	if (!activePlayer) return null;
+
+	return (
+		<Button
+			aria-label={addLabel}
+			disabled={disabled}
+			size={size}
+			type="button"
+			variant={variant}
+			className={cn(
+				"flex-shrink-0 rounded-lg text-neutral-950 dark:text-neutral-50",
+				className,
+			)}
+			onClick={() => {
+				onAdd();
+			}}
+		>
+			<IconPlus className="h-4 w-4" />
+		</Button>
+	);
+};

--- a/apps/stardew.app/src/components/cards/shipping-card.tsx
+++ b/apps/stardew.app/src/components/cards/shipping-card.tsx
@@ -12,6 +12,7 @@ import { usePlayers } from "@/contexts/players-context";
 import { CreatePlayerRedirect } from "@/components/createPlayerRedirect";
 import { NewItemBadge } from "@/components/new-item-badge";
 import { Button } from "@/components/ui/button";
+import { CardQuickActions } from "@/components/cards/card-quick-actions";
 import {
 	Dialog,
 	DialogContent,
@@ -24,7 +25,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
-import { IconChevronRight, IconExternalLink, IconPlus } from "@tabler/icons-react";
+import { IconChevronRight, IconExternalLink } from "@tabler/icons-react";
 
 interface Props {
 	item: ShippingItem;
@@ -166,23 +167,13 @@ export const ShippingCard = ({ item, show, setPromptOpen }: Props) => {
 						<IconChevronRight className="h-5 w-5 flex-shrink-0 text-neutral-500 dark:text-neutral-400" />
 					</div>
 				</DialogTrigger>
-				{activePlayer && (
-					<Button
-						aria-label={`Increment ${name} shipped count`}
-						size="icon"
-						type="button"
-						variant="outline"
-						className={cn(
-							"flex-shrink-0 rounded-lg text-neutral-950 dark:text-neutral-50",
-							classes[_status],
-						)}
-						onClick={() => {
-							incrementShippedCount();
-						}}
-					>
-						<IconPlus className="h-4 w-4" />
-					</Button>
-				)}
+				<CardQuickActions
+					addLabel={`Increment ${name} shipped count`}
+					className={classes[_status]}
+					onAdd={() => {
+						incrementShippedCount();
+					}}
+				/>
 			</div>
 			<DialogContent>
 				<DialogHeader>

--- a/apps/stardew.app/src/components/cards/shipping-card.tsx
+++ b/apps/stardew.app/src/components/cards/shipping-card.tsx
@@ -24,7 +24,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
-import { IconChevronRight, IconExternalLink } from "@tabler/icons-react";
+import { IconChevronRight, IconExternalLink, IconPlus } from "@tabler/icons-react";
 
 interface Props {
 	item: ShippingItem;
@@ -88,69 +88,102 @@ export const ShippingCard = ({ item, show, setPromptOpen }: Props) => {
 	const iconURL = `https://cdn.stardew.app/images/(O)${item.itemID}.webp`;
 	const name = objects[item.itemID as keyof typeof objects].name;
 	const description = objects[item.itemID as keyof typeof objects].description;
+	const isNewItemHidden =
+		item.minVersion === "1.6.0" && !show && _status < 1;
 
-	async function handleSave() {
+	async function updateShippedCount(nextCount: number) {
 		if (!activePlayer) return;
 
+		const patch = {
+			shipping: {
+				shipped: {
+					[item.itemID]: nextCount === 0 ? null : nextCount,
+				},
+			},
+		};
+
+		await patchPlayer(patch);
+	}
+
+	async function handleSave() {
 		// don't make any requests if the value hasn't changed
 		if (value === _count || value < 0) {
 			setOpen(false);
 			return;
 		}
 
-		const patch = {
-			shipping: {
-				shipped: {
-					[item.itemID]: value === 0 ? null : value,
-				},
-			},
-		};
-
-		await patchPlayer(patch);
+		await updateShippedCount(value);
 		setOpen(false);
+	}
+
+	async function incrementShippedCount() {
+		if (isNewItemHidden) {
+			setPromptOpen?.(true);
+			return;
+		}
+
+		await updateShippedCount(_count + 1);
 	}
 	return (
 		<Dialog open={open} onOpenChange={setOpen}>
-			<DialogTrigger asChild>
-				<div
-					className={cn(
-						"relative flex select-none items-center justify-between rounded-lg border px-5 py-4 text-left text-neutral-950 shadow-sm transition-colors hover:cursor-pointer dark:text-neutral-50",
-						classes[_status],
-					)}
-					onClick={(e) => {
-						if (item.minVersion === "1.6.0" && !show && _status < 1) {
-							e.preventDefault();
-							setPromptOpen?.(true);
-							return;
-						}
-					}}
-				>
-					{item.minVersion === "1.6.0" && (
-						<NewItemBadge version={item.minVersion} />
-					)}
+			<div className="flex w-full items-center gap-2">
+				<DialogTrigger asChild>
 					<div
 						className={cn(
-							"flex items-center space-x-3 truncate text-left",
-							item.minVersion === "1.6.0" && !show && _status < 1 && "blur-sm",
+							"relative flex min-w-0 flex-1 select-none items-center justify-between rounded-lg border px-5 py-4 text-left text-neutral-950 shadow-sm transition-colors hover:cursor-pointer dark:text-neutral-50",
+							classes[_status],
 						)}
+						onClick={(e) => {
+							if (isNewItemHidden) {
+								e.preventDefault();
+								setPromptOpen?.(true);
+							}
+						}}
 					>
-						<Image
-							src={iconURL}
-							alt={name}
-							className="rounded-sm"
-							width={32}
-							height={32}
-						/>
-						<div className="min-w-0 flex-1 pr-3">
-							<p className="truncate font-medium">{`${name} (${_count}x)`}</p>
-							<p className="truncate text-sm text-neutral-500 dark:text-neutral-400">
-								{description}
-							</p>
+						{item.minVersion === "1.6.0" && (
+							<NewItemBadge version={item.minVersion} />
+						)}
+						<div
+							className={cn(
+								"flex items-center space-x-3 truncate text-left",
+								isNewItemHidden && "blur-sm",
+							)}
+						>
+							<Image
+								src={iconURL}
+								alt={name}
+								className="rounded-sm"
+								width={32}
+								height={32}
+							/>
+							<div className="min-w-0 flex-1 pr-3">
+								<p className="truncate font-medium">{`${name} (${_count}x)`}</p>
+								<p className="truncate text-sm text-neutral-500 dark:text-neutral-400">
+									{description}
+								</p>
+							</div>
 						</div>
+						<IconChevronRight className="h-5 w-5 flex-shrink-0 text-neutral-500 dark:text-neutral-400" />
 					</div>
-					<IconChevronRight className="h-5 w-5 flex-shrink-0 text-neutral-500 dark:text-neutral-400" />
-				</div>
-			</DialogTrigger>
+				</DialogTrigger>
+				{activePlayer && (
+					<Button
+						aria-label={`Increment ${name} shipped count`}
+						size="icon"
+						type="button"
+						variant="outline"
+						className={cn(
+							"flex-shrink-0 rounded-lg text-neutral-950 dark:text-neutral-50",
+							classes[_status],
+						)}
+						onClick={() => {
+							incrementShippedCount();
+						}}
+					>
+						<IconPlus className="h-4 w-4" />
+					</Button>
+				)}
+			</div>
 			<DialogContent>
 				<DialogHeader>
 					<Image


### PR DESCRIPTION
<img width="1509" height="547" alt="image" src="https://github.com/user-attachments/assets/701f81ae-ee2d-4627-aabc-7a6fd502d292" />

I found myself struggling to quickly input my save data into the app, so I figured I'd make my life a bit easier!
This PR adds the ability to quickly increment the value of any card by simply clicking the "plus" button next to the card. 
This has been implemented in a way that allows extensibility and reuse across the app. (it could be quite useful for the museum etc where you only need to mark things as "collected" etc)

Obviously this doesn't have to stop with a simple "increment by one" but I thought I'd just keep it simple for now, so that code owners can see what they think first.

I didn't know what your thoughts might be on styling, the button will inherit the color of the card, not sure if this is preferred? But I thought it looked alright so I left it as is.

Hope this is useful! 